### PR TITLE
Fix missing username for UID error.

### DIFF
--- a/master_openworm.py
+++ b/master_openworm.py
@@ -100,7 +100,7 @@ OW_OUT_DIR = os.environ['OW_OUT_DIR']
 
 
 try:
-    if pwd.getpwuid(os.stat(OW_OUT_DIR).st_uid).pw_name != os.environ['USER']:
+    if os.access(OW_OUT_DIR, os.W_OK) is not True:
         os.system('sudo chown -R %s:%s %s' % (os.environ['USER'], os.environ['USER'], OW_OUT_DIR))
 except:
     print("Unexpected error: %s" % sys.exc_info()[0])


### PR DESCRIPTION
If the UID of the user who owns the "shared" directory does not correlate to a username inside of the container, the system experiences a critical stop. This change instructs the system to check for write access in the target directory regardless of current owner, fixing this issue and potentially preventing unnecessary permission modifications.