### PR TITLE
Use canonical version to tag windows docker build.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,1 +1,2 @@
-docker build -t "openworm/openworm:0.9.3" .
+@SET /P version=<VERSION
+docker build -t openworm/openworm:%version% .


### PR DESCRIPTION
Minor fix.  Uses version file to tag the build, instead of hard-coding the version in the script.