### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN  sudo update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 10
 ################################################################################
 ########     Install NEURON simulator
 
-RUN pip3 install neuron==8.0.1
+RUN sudo pip3 install neuron==8.1.0
 
 
 ################################################################################


### PR DESCRIPTION
fix bugs:
1.[ 9/28] RUN pip3 install neuron==8.0.1:                                                                                                                                                                                                         0.252 WARNING: The directory '/home/ow/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag. 1.575 ERROR: Could not find a version that satisfies the requirement neuron==8.0.1 (from versions: 8.1a0, 8.1.0, 8.2, 8.2.1, 8.2.2, 8.2.3, 8.2.4) 1.576 ERROR: No matching distribution found for neuron==8.0.1 
2.ERROR: Could not find a version that satisfies the requirement neuron==8.0.1 (from versions: 8.1a0, 8.1.0, 8.2, 8.2.1, 8.2.2, 8.2.3, 8.2.4)