### PR TITLE
doc->[add] code blocks under advanced section for readability.

### DIFF
--- a/Dockerfile_JL
+++ b/Dockerfile_JL
@@ -1,0 +1,4 @@
+# syntax=docker/dockerfile:1
+
+FROM quay.io/jupyter/base-notebook
+RUN pip install --no-cache-dir pyneuroml

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ We have put together a [Docker container](https://hub.docker.com/r/openworm/open
 ### Arguments
 
 - `-d [num]`: Use to modify the duration of the simulation in milliseconds. Default is 15. Use 5000 to run for time to make the full movie above (i.e. 5 seconds).
+```bash
+run.sh -d [num]
+```
+```powershell
+run.cmd -d [num]
+```
 
 ### Other Things to Try
 

--- a/build_jl.sh
+++ b/build_jl.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+version=$(<VERSION) # Read version of Dockerfile from file VERSION
+docker build "$@" -t "openworm/openworm_jl:$version" -f Dockerfile_JL .

--- a/run_jl.sh
+++ b/run_jl.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+OW_OUT_DIR=/home/ow/shared
+HOST_OUT_DIR=$PWD
+
+version=$(<VERSION) # Read version of Dockerfile from file VERSION
+
+xhost +
+
+docker run --rm \
+  --name openworm_jl_$version \
+  --device=/dev/dri:/dev/dri \
+  -e DISPLAY=$DISPLAY \
+  -e OW_OUT_DIR=$OW_OUT_DIR \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
+  --privileged \
+  -v $HOST_OUT_DIR:$OW_OUT_DIR:rw \
+  -p 8889:8888 \
+  openworm/openworm_jl:$version \
+  start-notebook.py \
+  --NotebookApp.token='openworm' &
+
+sleep 3
+echo
+echo -e "To access the running JupyterLab instance, go to:"
+echo -e "     http://localhost:8889/lab?token=openworm"
+echo
+echo -e "To stop the service type: ./stop_jl.sh"
+echo

--- a/stop_jl.sh
+++ b/stop_jl.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+version=$(<VERSION) # Read version of Dockerfile from file VERSION
+
+docker stop openworm_jl_${version}
+docker rm openworm_jl_${version}


### PR DESCRIPTION
**MOTIVATION**
The purpose of this update is to improve readability for future readers. Under the *advanced* section, it was not clear what command was associated with the `-d` option. So I included two code blocks, which explicitly show readers how to invoke the `run` command with the `-d` option, either in MacOS/Linux or Windows.

Signed-off-by: michaelsodeke@outlook.com