### PR TITLE
 Create JupyterLab based version of Dockerfile #347

### DIFF
--- a/docker/Dockerfile-jupyter
+++ b/docker/Dockerfile-jupyter
@@ -1,0 +1,5 @@
+FROM openworm/openworm:latest
+
+RUN python -m pip install --user jupyterlab
+
+ENTRYPOINT ["python3", "-m", "jupyterlab", "--allow-root", "--ip", "0.0.0.0"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,25 @@
+# Docker Related Files
+
+## Prerequisites
+
+Installed and configured docker and docker-compose are necessary to successfully
+run the container.
+
+## Building and running the container
+
+The container is build by
+```
+docker-compose build
+```
+and started by
+```
+docker-compose up -d
+```
+
+## JupyterLab setup
+
+To enter to the JupyterLab instance start the container and open
+http://127.0.0.1:8888/lab
+
+All the programs available in the openworm/openworm image are available in the
+jupyterlab interface.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3"
+services:
+  jupyter:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile-jupyter
+    volumes:
+      - ../output:/home/ow/shared/output/
+    network_mode: host
+    # user: ${MY_UID}:${MY_GID}
+    entrypoint: python3 -m jupyterlab --allow-root --NotebookApp.token=''


### PR DESCRIPTION
This is the start of the jupyterlab interface as requested in issue #347 . It is based on the openworm/openworm docker image, so it contains all required packages including precompiled sibernetic.

It is meant to be used with docker-compose, which is the standard way of making more complex docker workflow (and my suggestion would be to change also other containers in this way). After starting the docker container with `docker-compose up` (as described in docker/README.md), the jupyter interface is available on http://localhost:8888

To fully comply with the request in the issue #347, it should also include Jupyter notebook with some usage example. However, it fails to finish for me at the moment, so I leave it up to someone more experienced with openworm.

