### PR TITLE
Add the jupyterlab for compatibility with binder

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,3 +122,5 @@ RUN echo '\n\nalias cd..="cd .."\nalias h=history\nalias ll="ls -alt"' >> ~/.bas
 RUN pip list
 
 RUN echo "Built the OpenWorm Docker image!"
+
+RUN python3 -m pip install --no-cache-dir notebook jupyterlab


### PR DESCRIPTION
This merge request sets the Dockerfile for the compatiblity with mybinder service. To test just follow the link [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/tomichec/OpenWorm/287-mybinder), but note: patience might be needed as building, pushing and pulling the container takes time.

At the moment a jupyter notebook is still not available.

This PR is related to https://github.com/openworm/OpenWorm/pull/356 , but simpler. Probably better to include this first, and then change the second to only use the docker image instead of building separate image for jupyter.


Inspired:
https://mybinder.readthedocs.io/en/latest/tutorials/dockerfile.html#preparing-your-dockerfile