### PR TITLE
Remove unnecessary int conversion in master_openworm.py

### DIFF
--- a/master_openworm.py
+++ b/master_openworm.py
@@ -309,7 +309,7 @@ if black_start_pos != -1:
     black_dur = float(out[black_dur_pos + len("black_duration:") :])
 
 if black_start == 0.0 and black_dur:
-    black_dur = int(math.ceil(black_dur))
+    black_dur = math.ceil(black_dur)
     command = "ffmpeg -ss 00:00:0%s -i %s/%s -c copy -avoid_negative_ts 1 %s/cut_%s" % (
         black_dur,
         new_sim_out,


### PR DESCRIPTION
math.ceil returns an integer so the int call is unnecessary