### PR TITLE
⚡ Performance: Add simulation orchestration script with memory limit

### DIFF
--- a/scripts/run_simulation.sh
+++ b/scripts/run_simulation.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SIM_TIME=${SIM_TIME:-1000}
+OUTPUT_DIR=${OUTPUT_DIR:-./output}
+MEM_LIMIT=${MEM_LIMIT:-2000000}
+
+mkdir -p "$OUTPUT_DIR"
+
+ulimit -v "$MEM_LIMIT"
+
+c302 run --time "$SIM_TIME" --output "$OUTPUT_DIR/c302_output"
+
+sibernetic run --time "$SIM_TIME" --output "$OUTPUT_DIR/sibernetic_output"
+
+FRAME_DIR="$OUTPUT_DIR/frames"
+if [ -d "$FRAME_DIR" ]; then
+  ffmpeg -y -framerate 30 -i "$FRAME_DIR/frame_%04d.png" -c:v libx264 -pix_fmt yuv420p "$OUTPUT_DIR/simulation.mp4"
+  rm -rf "$FRAME_DIR"
+fi


### PR DESCRIPTION
## Problem

Create a bash script that orchestrates running the c302 and Sibernetic simulations, sets a virtual memory limit to mitigate memory leaks, and triggers video generation after simulation completes. The script will use environment variables to configure simulation time and output directories. It will also handle cleanup of intermediate frames to reduce disk usage.

**Severity**: `medium`
**File**: `scripts/run_simulation.sh`

## Solution

Implemented the necessary changes to address the identified issue in `scripts/run_simulation.sh`.

## Changes

- `scripts/run_simulation.sh` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #341