### PR TITLE
Fix the uid conflict in Docker image by removing ubuntu user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,18 +5,16 @@ LABEL maintainer="David Lung (lungdm@gmail.com); Padraig Gleeson (p.gleeson@gmai
 ARG USR=ow
 ENV USER=$USR
 
+RUN touch /var/mail/ubuntu && chown ubuntu /var/mail/ubuntu && userdel -r ubuntu
+
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get dist-upgrade -y
 
-RUN mkdir -p /etc/sudoers.d && \
-  export uid=1000 gid=1000 && \
-  mkdir -p /home/$USER && \
-  echo "$USER:x:${uid}:${gid}:$USER,,,:/home/$USER:/bin/bash" >> /etc/passwd && \
-  echo "$USER:x:${uid}:" >> /etc/group && \
-  echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USER && \
-  chmod 0440 /etc/sudoers.d/$USER && \
-  chown ${uid}:${gid} -R /home/$USER
+RUN apt-get update && apt-get install -y sudo && \
+    useradd -m -s /bin/bash -u 1000 $USER && \
+    echo "$USER ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USER && \
+    chmod 0440 /etc/sudoers.d/$USER
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Ubuntu 24.04 docker images now includes user ubuntu with UID/GID 1000[1], in the dockerfile we are adding user ow with the same uid. This is causing issue when trying to use the dockerfile with devcontainers and it doesn't make any sense to have two different users with same uid so removing the ubuntu user using the instructions from ubuntu bug report[2] for this change.

also adding user using useradd instead of manually changing bunch of files and installing sudo package so we don't have to create /etc/sudoers.d manually

[1] https://askubuntu.com/questions/1513927/ubuntu-24-04-docker-images-now-includes-user-ubuntu-with-uid-gid-1000
[2] https://bugs.launchpad.net/cloud-images/+bug/2005129/comments/2